### PR TITLE
Updated to use Alpine JRE image

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to run an OrientDB (Graph) Container
 ############################################################
 
-FROM java:openjdk-8-jdk-alpine
+FROM java:openjdk-8-jre-alpine
 
 MAINTAINER OrientDB LTD (info@orientdb.com)
 


### PR DESCRIPTION
Since runtime of OrientDB does not require full JDK, the base image can
be changed to use the JRE version of Alpine.
