### PR TITLE
Dockerfile of orientDB image - ppc64le

### DIFF
--- a/2.2/ppc64le/ubuntu/Dockerfile
+++ b/2.2/ppc64le/ubuntu/Dockerfile
@@ -1,0 +1,47 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+#FROM java:openjdk-8-jdk-alpine
+#Base image for this dockerfile
+FROM ppc64le/ibmjava:latest
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 2.2.8
+ENV ORIENTDB_DOWNLOAD_MD5 418d506886b306f87b77d9f4bfa8da65
+ENV ORIENTDB_DOWNLOAD_SHA1 df09a34b2d27f8a1bf114e67818af4e6c6369a3e
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-community/$ORIENTDB_VERSION/orientdb-community-$ORIENTDB_VERSION.tar.gz
+
+#RUN apk add --update tar \
+#    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and delete databases
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-community-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-community-$ORIENTDB_VERSION.tar.gz \
+  && rm -rf /orientdb/databases/*
+
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]


### PR DESCRIPTION
Created folder - "ppc64le/ubuntu" under 2.2  to create a dockerfile. Have tested this dockefile -- docker image ( orientdb ) and also seen the studio was viewed too as well .

Here inside the dockerfile , we have used the official dockerhub image : ppc64le/ibmjava:latest.

Attempted to provide a docker image for ppc64le architecture.
Hi @robfrank  , 
This is in response to the communication which we had some time back and you have suggested that i raise a PR for this .

Please advise further action.