### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to run an OrientDB (Graph) Container
 ############################################################
 
-FROM java:8-jdk
+FROM openjdk:8-jdk
 
 MAINTAINER OrientDB LTD (info@orientdb.com)
 

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to run an OrientDB (Graph) Container
 ############################################################
 
-FROM java:openjdk-8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 MAINTAINER OrientDB LTD (info@orientdb.com)
 

--- a/2.2/x86_64/alpine/Dockerfile
+++ b/2.2/x86_64/alpine/Dockerfile
@@ -2,7 +2,7 @@
 # Dockerfile to run an OrientDB (Graph) Container
 ############################################################
 
-FROM java:openjdk-8-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 MAINTAINER OrientDB LTD (info@orientdb.com)
 


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).