### PR TITLE
adds docker file for tinker pop 3.x version

### DIFF
--- a/3.0-tp3/x86_64/alpine/Dockerfile
+++ b/3.0-tp3/x86_64/alpine/Dockerfile
@@ -1,0 +1,47 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 3.0.1
+ENV ORIENTDB_DOWNLOAD_MD5 8f3a632ebbf1314c1842a42d46411037
+ENV ORIENTDB_DOWNLOAD_SHA1 20a3c1d4ac3b7a1ff4bfceb778179fe770d2876b
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-tp3/$ORIENTDB_VERSION/orientdb-tp3-$ORIENTDB_VERSION.tar.gz
+
+RUN apk add --update tar curl \
+    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and DON'T delete databases (tp3 endopoint won't works if db isn't present)
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-tp3-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-tp3-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-tp3-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-tp3-$ORIENTDB_VERSION.tar.gz
+
+#overrides internal gremlin-server to set binding to 0.0.0.0 instead of localhost
+ADD gremlin-server.yaml /orientdb/config
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]
+

--- a/3.0-tp3/x86_64/alpine/gremlin-server.yaml
+++ b/3.0-tp3/x86_64/alpine/gremlin-server.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+host: 0.0.0.0
+port: 8182
+scriptEvaluationTimeout: 30000
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager : com.orientechnologies.tinkerpop.server.OrientGremlinGraphManager
+graphs: {
+  graph : ../config/demodb.properties
+}
+scriptEngines: {
+  gremlin-groovy: {
+    plugins: { org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.orientdb.jsr223.OrientDBGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
+               org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [../config/demodb.groovy]}}}}
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.orientdb.io.OrientIoRegistry] }}             # application/vnd.gremlin-v3.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}                                                                       # application/vnd.gremlin-v3.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.orientdb.io.OrientIoRegistry] }}         # application/json
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+  - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+metrics: {
+  consoleReporter: {enabled: true, interval: 180000},
+  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  jmxReporter: {enabled: true},
+  slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 65536
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferLowWaterMark: 32768
+writeBufferHighWaterMark: 65536
+authentication: {
+  authenticator: com.orientechnologies.tinkerpop.server.auth.OGremlinServerAuthenticator
+    }
+ssl: {
+  enabled: false}


### PR DESCRIPTION
3.x images don't expose gremlin server

this new docker file, with a custom gremlin-server-config file, provides it

NOTE: the demo db isn't deleted, because the gremlin config it's binded to it