### PR TITLE
Adding dockerfile changes for ppc64le

### DIFF
--- a/2.2-spatial/ppc64le/alpine/Dockerfile
+++ b/2.2-spatial/ppc64le/alpine/Dockerfile
@@ -1,0 +1,15 @@
+############################################################
+# Dockerfile  for OrientDB with spatial module and neo4j connector
+############################################################
+
+FROM orientdb:2.2.37
+
+ENV ORIENTDB_DOWNLOAD_SPATIAL_MD5 9f64ab5e959f5d9ad9ea5195d6d621d2
+ENV ORIENTDB_DOWNLOAD_SPATIAL_SHA1 1748c9779ea7a8cb8fc068fcabf960e1778e8a19
+
+ENV ORIENTDB_DOWNLOAD_SPATIAL_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-spatial/$ORIENTDB_VERSION/orientdb-spatial-$ORIENTDB_VERSION-dist.jar
+
+RUN wget $ORIENTDB_DOWNLOAD_SPATIAL_URL \
+    && echo "$ORIENTDB_DOWNLOAD_SPATIAL_MD5 *orientdb-spatial-$ORIENTDB_VERSION-dist.jar" | md5sum -c - \
+    && echo "$ORIENTDB_DOWNLOAD_SPATIAL_SHA1 *orientdb-spatial-$ORIENTDB_VERSION-dist.jar" | sha1sum -c - \
+    && mv orientdb-spatial-*-dist.jar /orientdb/lib/

--- a/2.2-spatial/ppc64le/openjdk-slim/Dockerfile
+++ b/2.2-spatial/ppc64le/openjdk-slim/Dockerfile
@@ -1,0 +1,15 @@
+############################################################
+# Dockerfile  for OrientDB with spatial module and neo4j connector
+############################################################
+
+FROM orientdb:2.2.37
+
+ENV ORIENTDB_DOWNLOAD_SPATIAL_MD5 9f64ab5e959f5d9ad9ea5195d6d621d2
+ENV ORIENTDB_DOWNLOAD_SPATIAL_SHA1 1748c9779ea7a8cb8fc068fcabf960e1778e8a19
+
+ENV ORIENTDB_DOWNLOAD_SPATIAL_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-spatial/$ORIENTDB_VERSION/orientdb-spatial-$ORIENTDB_VERSION-dist.jar
+
+RUN wget $ORIENTDB_DOWNLOAD_SPATIAL_URL \
+    && echo "$ORIENTDB_DOWNLOAD_SPATIAL_MD5 *orientdb-spatial-$ORIENTDB_VERSION-dist.jar" | md5sum -c - \
+    && echo "$ORIENTDB_DOWNLOAD_SPATIAL_SHA1 *orientdb-spatial-$ORIENTDB_VERSION-dist.jar" | sha1sum -c - \
+    && mv orientdb-spatial-*-dist.jar /orientdb/lib/

--- a/2.2/ppc64le/alpine/Dockerfile
+++ b/2.2/ppc64le/alpine/Dockerfile
@@ -1,0 +1,46 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 2.2.37
+ENV ORIENTDB_DOWNLOAD_MD5 cb80556ef3b0260d0ee5de88ea73fb9d
+ENV ORIENTDB_DOWNLOAD_SHA1 469c402dde029f265fe905de2c08b43960e81f07
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-community/$ORIENTDB_VERSION/orientdb-community-$ORIENTDB_VERSION.tar.gz
+
+RUN apk add --update tar curl \
+    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and delete databases
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-community-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-community-$ORIENTDB_VERSION.tar.gz \
+  && rm -rf /orientdb/databases/*
+
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]
+

--- a/3.0-spatial/ppc64le/alpine/Dockerfile
+++ b/3.0-spatial/ppc64le/alpine/Dockerfile
@@ -1,0 +1,46 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 3.0.21
+ENV ORIENTDB_DOWNLOAD_MD5 3cbefb38827222fe2e700f05bf0bd23e
+ENV ORIENTDB_DOWNLOAD_SHA1 016701d58f5a3f89d727edf395206bf366e9475c
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-community/$ORIENTDB_VERSION/orientdb-community-$ORIENTDB_VERSION.tar.gz
+
+RUN apk add --update tar curl \
+    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and delete databases
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-community-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-community-$ORIENTDB_VERSION.tar.gz \
+  && rm -rf /orientdb/databases/*
+
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]
+

--- a/3.0-tp3/ppc64le/alpine/Dockerfile
+++ b/3.0-tp3/ppc64le/alpine/Dockerfile
@@ -1,0 +1,51 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 3.0.21
+ENV ORIENTDB_DOWNLOAD_MD5 bf74343a229da02d54f49e21e35e8134
+ENV ORIENTDB_DOWNLOAD_SHA1 82cc52fe21ae390bb5bf70471f71655d562eebc3
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-tp3/$ORIENTDB_VERSION/orientdb-tp3-$ORIENTDB_VERSION.tar.gz
+
+RUN apk add --update tar curl \
+    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and DON'T delete databases (tp3 endopoint won't works if db isn't present)
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-tp3-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-tp3-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-tp3-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-tp3-$ORIENTDB_VERSION.tar.gz \
+  && rm -rf /orientdb/databases/*
+
+#overrides internal gremlin-server to set binding to 0.0.0.0 instead of localhost
+ADD gremlin-server.yaml /orientdb/config
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+#Gremlin server
+EXPOSE 8182
+
+# Default command start the server
+CMD ["server.sh"]
+

--- a/3.0-tp3/ppc64le/alpine/gremlin-server.yaml
+++ b/3.0-tp3/ppc64le/alpine/gremlin-server.yaml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+host: 0.0.0.0
+port: 8182
+scriptEvaluationTimeout: 30000
+channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
+graphManager : com.orientechnologies.tinkerpop.server.OrientGremlinGraphManager
+graphs: {
+  graph : ../config/demodb.properties
+}
+scriptEngines: {
+  gremlin-groovy: {
+    plugins: { org.apache.tinkerpop.gremlin.server.jsr223.GremlinServerGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.orientdb.jsr223.OrientDBGremlinPlugin: {},
+               org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]},
+               org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [../config/demodb.groovy]}}}}
+serializers:
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.orientdb.io.OrientIoRegistry] }}             # application/vnd.gremlin-v3.0+gryo
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}                                                                       # application/vnd.gremlin-v3.0+gryo-stringd
+  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.apache.tinkerpop.gremlin.orientdb.io.OrientIoRegistry] }}         # application/json
+processors:
+  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
+  - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+metrics: {
+  consoleReporter: {enabled: true, interval: 180000},
+  csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv},
+  jmxReporter: {enabled: true},
+  slf4jReporter: {enabled: true, interval: 180000}}
+strictTransactionManagement: false
+maxInitialLineLength: 4096
+maxHeaderSize: 8192
+maxChunkSize: 8192
+maxContentLength: 65536
+maxAccumulationBufferComponents: 1024
+resultIterationBatchSize: 64
+writeBufferLowWaterMark: 32768
+writeBufferHighWaterMark: 65536
+authentication: {
+  authenticator: com.orientechnologies.tinkerpop.server.auth.OGremlinServerAuthenticator
+    }
+ssl: {
+  enabled: false}

--- a/3.0/ppc64le/alpine/Dockerfile
+++ b/3.0/ppc64le/alpine/Dockerfile
@@ -1,0 +1,46 @@
+############################################################
+# Dockerfile to run an OrientDB (Graph) Container
+############################################################
+
+FROM openjdk:8-jdk-alpine
+
+MAINTAINER OrientDB LTD (info@orientdb.com)
+
+# Override the orientdb download location with e.g.:
+#   docker build -t mine --build-arg ORIENTDB_DOWNLOAD_SERVER=http://repo1.maven.org/maven2/com/orientechnologies/ .
+ARG ORIENTDB_DOWNLOAD_SERVER
+
+ENV ORIENTDB_VERSION 3.0.21
+ENV ORIENTDB_DOWNLOAD_MD5 3cbefb38827222fe2e700f05bf0bd23e
+ENV ORIENTDB_DOWNLOAD_SHA1 016701d58f5a3f89d727edf395206bf366e9475c
+
+ENV ORIENTDB_DOWNLOAD_URL ${ORIENTDB_DOWNLOAD_SERVER:-http://central.maven.org/maven2/com/orientechnologies}/orientdb-community/$ORIENTDB_VERSION/orientdb-community-$ORIENTDB_VERSION.tar.gz
+
+RUN apk add --update tar curl \
+    && rm -rf /var/cache/apk/*
+
+#download distribution tar, untar and delete databases
+RUN mkdir /orientdb && \
+  wget  $ORIENTDB_DOWNLOAD_URL \
+  && echo "$ORIENTDB_DOWNLOAD_MD5 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | md5sum -c - \
+  && echo "$ORIENTDB_DOWNLOAD_SHA1 *orientdb-community-$ORIENTDB_VERSION.tar.gz" | sha1sum -c - \
+  && tar -xvzf orientdb-community-$ORIENTDB_VERSION.tar.gz -C /orientdb --strip-components=1 \
+  && rm orientdb-community-$ORIENTDB_VERSION.tar.gz \
+  && rm -rf /orientdb/databases/*
+
+
+ENV PATH /orientdb/bin:$PATH
+
+VOLUME ["/orientdb/backup", "/orientdb/databases", "/orientdb/config"]
+
+WORKDIR /orientdb
+
+#OrientDb binary
+EXPOSE 2424
+
+#OrientDb http
+EXPOSE 2480
+
+# Default command start the server
+CMD ["server.sh"]
+


### PR DESCRIPTION
My intent is to have "ppc64le" built officially - https://github.com/docker-library/official-images/blob/master/library/orientdb
For Dockerfile which contain "openjdk:8-jdk-slim" as the base image  wont work for power as tag due to below reason
"no matching manifest for linux/ppc64le in the manifest list entries"
As "alpine" base image is already multi-arch image , those images get created successfully.
Have created "ppc64le" folders for all versions as done for "x86_64".

Confirmation of the image builds completing successfully on ppc64le m/c for the versions sought to be added in this PR.
```
# arch
ppc64le

# docker images | grep "2.0.18"
orientdb                                               2.0.18                         8c243f58e671        5 hours ago         717MB
# docker images | grep "2.2.37"
orientdb                                               2.2.37                         bbdeceaa4974        5 hours ago         171MB
# docker images | grep 3.0.21
orientdb                                               3.0.21                         23aca82658e3        3 hours ago         161MB

```

@luigidellaquila  , @laa  - Any review comments here - please ?